### PR TITLE
Start charts from minimum value

### DIFF
--- a/components/BarChart.vue
+++ b/components/BarChart.vue
@@ -23,9 +23,15 @@ export default {
     max: {
       type: Number,
       default: 20
+    },
+    min: {
+      type: Number,
+      default: null
     }
   },
   data () {
+    const max = parseInt(this.max) || 20
+    const min = parseInt(this.min) || (max / 5)
     return {
       options: {
         legend: {
@@ -40,7 +46,8 @@ export default {
           categories: this.data.map(({ title }) => title)
         },
         yaxis: {
-          max: parseInt(this.max)
+          max,
+          min
         },
         plotOptions: {
           bar: {

--- a/components/BarChartCompare.vue
+++ b/components/BarChartCompare.vue
@@ -23,9 +23,15 @@ export default {
     max: {
       type: Number,
       default: 20
+    },
+    min: {
+      type: Number,
+      default: null
     }
   },
   data () {
+    const max = parseInt(this.max) || 20
+    const min = parseInt(this.min) || (max / 5)
     return {
       options: {
         legend: {
@@ -40,7 +46,8 @@ export default {
           categories: this.data.map(({ title }) => title)
         },
         yaxis: {
-          max: parseInt(this.max) || 20
+          max,
+          min
         },
         plotOptions: {
           bar: {


### PR DESCRIPTION
Per information visualization best practices (I'll look up a source if
needed) the minimum possible value should be at the bottom of the chart
if the maximum is at the top of the chart.

Since the questions receive 1 to 5 points each, the minimum value for
all charts on the site is max/5. Make it the default for BarChart and
BarChartCompare, and add the `min` prop for explicit configuration.