### PR TITLE
Create a docker-compose file #105

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ Run to deploy
 vc --confirm
 ```
 
-## Deploy using [Docker](https://www.docker.com/)
+## Deploy using [Docker Compose](https://docs.docker.com/compose/)
 
-Todo
+```bash
+cd docker
+docker-compose up
+```
 
 ## Related
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+services:
+
+  node:
+    image: node:14
+    working_dir: /home/node/app
+    command: yarn dev
+    volumes:
+      - ../:/home/node/app
+    ports:
+      - "3000:3000"
+    environment:
+      MONGODB_URI: mongodb://mongolara
+      MONGODB_COLLECTION: results
+      BASE_URL: http://localhost:3000


### PR DESCRIPTION
As mentioned in https://github.com/rubynor/bigfive-web/issues/105#issuecomment-1278723454, this PR only includes the node image and not the mongodb, because the latter is not currently being used in the dev environment.

Feel free to close the PR if that's not acceptable.