### PR TITLE
Fix grammar errors in Chinese and change the "Chinese" name.

### DIFF
--- a/api/test/data/test-data.json
+++ b/api/test/data/test-data.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "zh-cn",
-      "text": "Chinese (PRC)"
+      "text": "Simplified Chinese"
     },
     {
       "id": "hi",

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -153,7 +153,7 @@ export default {
             dir: 'ltr'
           },
           {
-            name: 'Chinese',
+            name: 'Simplified Chinese',
             code: 'zh-Hans',
             iso: 'zh-Hans',
             file: 'zh-Hans.js',

--- a/translations/zh-Hans.js
+++ b/translations/zh-Hans.js
@@ -1,5 +1,5 @@
 export default {
-  language: 'Chinese',
+  language: 'Simplified Chinese',
   seo: {
     keywords: 'big five personality test, big 5 personality test, b5 test, bigfive test, personality traits, bigfive, compare, free, jordan peterson'
   },
@@ -21,7 +21,7 @@ export default {
     share: '与朋友分享，了解您的兼容性',
     cards: {
       open: {
-        title: '打开',
+        title: '开放',
         text: '这是 MIT 许可证下的开源项目'
       },
       free: {
@@ -30,11 +30,11 @@ export default {
       },
       scientific: {
         title: '科学',
-        text: 'BigFive 是一个经过科学验证且可靠的心理模型'
+        text: '五大人格是经过科学验证且可靠的心理模型'
       },
       translated: {
         title: '已翻译',
-        text: '翻译成 20 多种语言。帮助 <a href="https://b5.translations.alheimsins.net/" rel="noreferrer" target="blank">here</a>!'
+        text: '翻译成 20 多种语言。<a href="https://b5.translations.alheimsins.net/" rel="noreferrer" target="blank">点击这里</a>帮助翻译!'
       }
     },
     description: {
@@ -45,38 +45,38 @@ export default {
   <a href="http://ipip.ori.org" rel="noopener" target="_blank">ipip.ori.org</a>,
   inventory is from <i>Johnson's (2014) 120-item IPIP NEO-PI-R</i>.`,
       info: '以下测试包含 120 个问题，估计需要大约 10 分钟才能完成。',
-      result: 'After you have completed the test you will receive a detailed personality report in the following domains:',
-      tests_taken: 'tests taken so far'
+      result: '完成测试后，您将取得与详尽地人格报告。该报告将记载以下领域：',
+      tests_taken: '目前为止完成的测验'
     }
   },
   about: {
     seo: {
-      title: 'About and the big five team',
+      title: '关于五大人格测试',
       description: 'BigFive has a very active and engaged team that is constantly striving to push BigFive forward.'
     }
   },
   toolbar: {
-    home: 'Home',
+    home: '首頁',
     result: '结果',
     compare: '比较',
     articles: '文章',
     privacy: '隐私',
     about: '关于我们',
     see_results: '查看您的结果',
-    compare_with: '与其他公司比较'
+    compare_with: '与其他人比较'
   },
   facets: {
     openness_to_experience: {
-      title: '对经验的开放性'
+      title: '经验开放性'
     },
     conscientiousness: {
-      title: '责任心'
+      title: '尽责性'
     },
     extraversion: {
-      title: '外向'
+      title: '外向性'
     },
     agreeableness: {
-      title: '同意'
+      title: '亲和性'
     },
     neuroticism: {
       title: '神经质'
@@ -95,7 +95,7 @@ export default {
     privacy: 'privacy',
     nextButton: 'Okey, next question',
     declineButton: 'continue without sharing',
-    prefferedLanguage: '我最喜欢的语言是',
+    prefferedLanguage: '我偏好的语言是',
     selectLanguage: '选择语言',
     iama: 'I am a',
     male: 'Male',
@@ -113,7 +113,7 @@ export default {
   test: {
     next: '下一个',
     back: '返回',
-    more: '更',
+    more: '更多',
     seeResults: '查看结果'
   },
   big_five: {
@@ -124,28 +124,28 @@ export default {
     }
   },
   openness_to_experience: {
-    title: '开放体验',
+    title: '经验开放性',
     seo: {
       title: 'Overview of the domain Openness To Experience.',
       description: 'Read more about the Openness To Experience domain in the b5 model'
     }
   },
   conscientiousness: {
-    title: '责任心',
+    title: '尽责性',
     seo: {
       title: 'Overview of the domain Conscientiousness',
       description: 'Read more about the Conscientiousness domain in the b5 model'
     }
   },
   extraversion: {
-    title: '外向',
+    title: '外向性',
     seo: {
       title: 'Overview of the domain Extraversion',
       description: 'Read more about the Extraversion domain in the b5 model'
     }
   },
   agreeableness: {
-    title: '同意',
+    title: '亲和性',
     seo: {
       title: 'Overview of the domain Agreeableness',
       description: 'Read more about the agreeableness domain in the b5 model'
@@ -159,11 +159,11 @@ export default {
     }
   },
   getCompare: {
-    title: '比较人员或团队',
+    title: '比较他人或团队',
     description1: '将五大人格测试的结果与多人进行比较。',
-    description2: '输入您从测试结果（即',
+    description2: '输入您从测试结果（比如',
     description3: '在 ID 输入字段中',
-    needToAddPeople: '您需要添加人员来比较他们',
+    needToAddPeople: '您需要添加要比较的人',
     addAnother: '添加其他人',
     addPerson: '添加人员',
     comparePeople: '比较人',
@@ -185,7 +185,7 @@ export default {
   },
   getResult: {
     result: '结果',
-    explanation: '如果您参加了测试并保存了 ID，则通过键入您得到的 ID（即',
+    explanation: '如果您参加了测试并保存了 ID，则通过键入您得到的 ID（比如',
     idInput: '在 ID 输入字段中',
     urlOrId: '结果的 URL 或 ID',
     getResult: '获取结果',
@@ -271,129 +271,129 @@ export default {
   opennessToExperience: {
     quote: 'Openness to Experience describes a dimension of cognitive style that distinguishes imaginative, creative people from down-to-earth, conventional people.',
     text1: `
-        <p>
-          Openness to Experience describes a dimension of cognitive style that distinguishes imaginative, creative people from down-to-earth, conventional people.
-        </p>
-        <p>
-          Open people are <b>intellectually curious, appreciative of art, and sensitive to beauty</b>.
-          They tend to be, compared to closed people, more <b>aware of their feelings</b>.
-          They tend to think and act in individualistic and nonconforming ways.
-        </p>
-        <p>
-          Intellectuals typically score high on Openness to Experience; consequently, this factor has also been called Culture or Intellect.
-        </p>
-      `,
+      <p>
+        Openness to Experience describes a dimension of cognitive style that distinguishes imaginative, creative people from down-to-earth, conventional people.
+      </p>
+      <p>
+        Open people are <b>intellectually curious, appreciative of art, and sensitive to beauty</b>.
+        They tend to be, compared to closed people, more <b>aware of their feelings</b>.
+        They tend to think and act in individualistic and nonconforming ways.
+      </p>
+      <p>
+        Intellectuals typically score high on Openness to Experience; consequently, this factor has also been called Culture or Intellect.
+      </p>
+    `,
     text2: `
-        <p>
-          Nonetheless, Intellect is probably best regarded as one aspect of openness to experience.
-          Scores on Openness to Experience are only modestly related to years of education and scores on standard intelligent tests.
-        </p>
-        <p>
-          Another characteristic of the open cognitive style is a facility for thinking in symbols and abstractions far removed from concrete experience.
-        </p>
-        <p>
-          Depending on the individual's specific intellectual abilities, this symbolic cognition may take the form of mathematical, logical, or geometric thinking, artistic and metaphorical use of language, music composition or performance, or one of the many visual or performing arts.
-        </p>
-        <div class="title">
-          Low scores
-        </div>
-        <p>
-          People with <b>low scores</b> on openness to experience tend to have <b>narrow, common interests</b>.
-        </p>
-        <p>
-          They prefer the <b>plain, straightforward</b>, and obvious over the complex, ambiguous, and subtle.
-        </p>
-        <p>
-          They may regard the arts and sciences with suspicion, regarding these endeavors as abstruse or of no practical use.
-        </p>
-        <p>
-          Closed people prefer familiarity over novelty; they are conservative and resistant to change.
-        </p>
-        <p>
-          Openness is often presented as healthier or more mature by psychologists, who are often themselves open to experience. However, open and closed styles of thinking are useful in different environments.
-        </p>
-        <p>
-        The intellectual style of the open person may serve a professor well, but research has shown that closed thinking is related to superior job performance in police work, sales, and a number of service occupations.
-        </p>
+      <p>
+        Nonetheless, Intellect is probably best regarded as one aspect of openness to experience.
+        Scores on Openness to Experience are only modestly related to years of education and scores on standard intelligent tests.
+      </p>
+      <p>
+        Another characteristic of the open cognitive style is a facility for thinking in symbols and abstractions far removed from concrete experience.
+      </p>
+      <p>
+        Depending on the individual's specific intellectual abilities, this symbolic cognition may take the form of mathematical, logical, or geometric thinking, artistic and metaphorical use of language, music composition or performance, or one of the many visual or performing arts.
+      </p>
+      <div class="title">
+        Low scores
+      </div>
+      <p>
+        People with <b>low scores</b> on openness to experience tend to have <b>narrow, common interests</b>.
+      </p>
+      <p>
+        They prefer the <b>plain, straightforward</b>, and obvious over the complex, ambiguous, and subtle.
+      </p>
+      <p>
+        They may regard the arts and sciences with suspicion, regarding these endeavors as abstruse or of no practical use.
+      </p>
+      <p>
+        Closed people prefer familiarity over novelty; they are conservative and resistant to change.
+      </p>
+      <p>
+        Openness is often presented as healthier or more mature by psychologists, who are often themselves open to experience. However, open and closed styles of thinking are useful in different environments.
+      </p>
+      <p>
+      The intellectual style of the open person may serve a professor well, but research has shown that closed thinking is related to superior job performance in police work, sales, and a number of service occupations.
+      </p>
 
-        <div class="title">
-          Imagination
-        </div>
-        <p>
-          To imaginative individuals, the real world is often too plain and ordinary.
-        </p>
-        <p>
-          <b>High scorers</b> on this scale use fantasy as a way of creating a richer, more interesting world.
-        </p>
-        <p>
-        <b>Low scorers</b> are on this scale are more oriented to facts than fantasy.
-        </p>
+      <div class="title">
+        Imagination
+      </div>
+      <p>
+        To imaginative individuals, the real world is often too plain and ordinary.
+      </p>
+      <p>
+        <b>High scorers</b> on this scale use fantasy as a way of creating a richer, more interesting world.
+      </p>
+      <p>
+      <b>Low scorers</b> are on this scale are more oriented to facts than fantasy.
+      </p>
 
-        <div class="title">
-          Artistic Interests
-        </div>
-        <p>
-        <b>High scorers</b> on this scale love beauty, both in art and in nature. They become easily involved and absorbed in artistic and natural events.
-        </p>
-        <p>
-          They are not necessarily artistically trained nor talented, although many will be. The defining features of this scale are interest in, and appreciation of natural and artificial beauty.
-        </p>
-        <p>
-          <b>Low scorers</b> lack aesthetic sensitivity and interest in the arts.
-        </p>
+      <div class="title">
+        Artistic Interests
+      </div>
+      <p>
+      <b>High scorers</b> on this scale love beauty, both in art and in nature. They become easily involved and absorbed in artistic and natural events.
+      </p>
+      <p>
+        They are not necessarily artistically trained nor talented, although many will be. The defining features of this scale are interest in, and appreciation of natural and artificial beauty.
+      </p>
+      <p>
+        <b>Low scorers</b> lack aesthetic sensitivity and interest in the arts.
+      </p>
 
-        <div class="title">
-          Emotionality
-        </div>
-        <p>
-          Persons high on Emotionality have good access to and awareness of their own feelings.
-        </p>
-        <p>
-          Low scorers are less aware of their feelings and tend not to express their emotions openly.
-        </p>
+      <div class="title">
+        Emotionality
+      </div>
+      <p>
+        Persons high on Emotionality have good access to and awareness of their own feelings.
+      </p>
+      <p>
+        Low scorers are less aware of their feelings and tend not to express their emotions openly.
+      </p>
 
-        <div class="title">
-          Adventurousness
-        </div>
-        <p>
-          High scorers on adventurousness are eager to try new activities, travel to foreign lands, and experience different things.
-        </p>
-        <p>
-          They find familiarity and routine boring, and will take a new route home just because it is different.
-        </p>
-        <p>
-          Low scorers tend to feel uncomfortable with change and prefer familiar routines.
-        </p>
+      <div class="title">
+        Adventurousness
+      </div>
+      <p>
+        High scorers on adventurousness are eager to try new activities, travel to foreign lands, and experience different things.
+      </p>
+      <p>
+        They find familiarity and routine boring, and will take a new route home just because it is different.
+      </p>
+      <p>
+        Low scorers tend to feel uncomfortable with change and prefer familiar routines.
+      </p>
 
-        <div class="title">
-          Intellect
-        </div>
-        <p>
-          Intellect and artistic interests are the two most important, central aspects of openness to experience. High scorers on Intellect love to play with ideas.
-        </p>
-        <p>
-          They are open-minded to new and unusual ideas, and like to debate intellectual issues. They enjoy riddles, puzzles, and brain teasers. Low scorers on Intellect prefer dealing with either people or things rather than ideas.
-        </p>
-        <p>
-          They regard intellectual exercises as a waste of time.
-        </p>
-        <p>
-          Intellect should not be equated with intelligence. Intellect is an intellectual style, not an intellectual ability, although high scorers on Intellect score slightly higher than low-Intellect individuals on standardized intelligence tests.
-        </p>
+      <div class="title">
+        Intellect
+      </div>
+      <p>
+        Intellect and artistic interests are the two most important, central aspects of openness to experience. High scorers on Intellect love to play with ideas.
+      </p>
+      <p>
+        They are open-minded to new and unusual ideas, and like to debate intellectual issues. They enjoy riddles, puzzles, and brain teasers. Low scorers on Intellect prefer dealing with either people or things rather than ideas.
+      </p>
+      <p>
+        They regard intellectual exercises as a waste of time.
+      </p>
+      <p>
+        Intellect should not be equated with intelligence. Intellect is an intellectual style, not an intellectual ability, although high scorers on Intellect score slightly higher than low-Intellect individuals on standardized intelligence tests.
+      </p>
 
-        <div class="title">
-          Liberalism
-        </div>
-        <p>
-          Psychological liberalism refers to a readiness to challenge authority, convention, and traditional values.
-        </p>
-        <p>
-          In its most extreme form, psychological liberalism can even represent outright hostility toward rules, sympathy for law-breakers, and love of ambiguity, chaos, and disorder.
-        </p>
-        <p>
-          Psychological conservatives prefer the security and stability brought by conformity to tradition. Psychological liberalism and conservatism are not identical to political affiliation, but certainly incline individuals toward certain political parties.
-        </p>
-      `
+      <div class="title">
+        Liberalism
+      </div>
+      <p>
+        Psychological liberalism refers to a readiness to challenge authority, convention, and traditional values.
+      </p>
+      <p>
+        In its most extreme form, psychological liberalism can even represent outright hostility toward rules, sympathy for law-breakers, and love of ambiguity, chaos, and disorder.
+      </p>
+      <p>
+        Psychological conservatives prefer the security and stability brought by conformity to tradition. Psychological liberalism and conservatism are not identical to political affiliation, but certainly incline individuals toward certain political parties.
+      </p>
+    `
   },
   neuroticismPage: {
     quote: 'Neuroticism refers to the tendency to experience negative feelings.',


### PR DESCRIPTION
1. Fix some obvious errors, like wrong noun names or grammar in Chinese. For example, in Big Five personality, "Openness to experience" is "[经验开放性](https://zh.wikipedia.org/wiki/经验开放性)" in Chinese instead of "开放体验" or "对经验的开放性" in the original content.
2. Change the language label "Chinese" to "Simplified Chinese": there are two writing systems in the Chinese language: the [Simplified Chinese](https://en.wikipedia.org/wiki/Simplified_Chinese) and the [Traditional Chinese](https://en.wikipedia.org/wiki/Traditional_Chinese). The current language code here "[zh-Hans](https://en.wikipedia.org/wiki/zh-Hans)" stands for the simplified one. Considering the traditional one is still "common use in Taiwan, Hong Kong and Macau, as well as in most overseas Chinese communities outside Southeast Asia", we need to distinguish them.