### PR TITLE
Fix typo ("have have" -> "have")

### DIFF
--- a/old-packages/results/lib/data/en/neuroticism.js
+++ b/old-packages/results/lib/data/en/neuroticism.js
@@ -88,7 +88,7 @@ nervous in social situations.`
       facet: 5,
       title: 'Immoderation',
       text: `Immoderate individuals feel strong cravings and
-urges that they have have difficulty resisting. They tend to be
+urges that they have difficulty resisting. They tend to be
 oriented toward short-term pleasures and rewards rather than long-
 term consequences. Low scorers do not experience strong, irresistible
 cravings and consequently do not find themselves tempted to overindulge.`

--- a/old-packages/results/lib/data/is/neuroticism.js
+++ b/old-packages/results/lib/data/is/neuroticism.js
@@ -63,7 +63,7 @@ nervous in social situations.`
       facet: 5,
       title: 'Immoderation',
       text: `Immoderate individuals feel strong cravings and
-urges that they have have difficulty resisting. They tend to be
+urges that they have difficulty resisting. They tend to be
 oriented toward short-term pleasures and rewards rather than long-
 term consequences. Low scorers do not experience strong, irresistible
 cravings and consequently do not find themselves tempted to overindulge.`

--- a/old-packages/results/test/data/get-template-en.json
+++ b/old-packages/results/test/data/get-template-en.json
@@ -146,7 +146,7 @@
       {
         "facet": 5,
         "title": "Immoderation",
-        "text": "Immoderate individuals feel strong cravings and\nurges that they have have difficulty resisting. They tend to be\noriented toward short-term pleasures and rewards rather than long-\nterm consequences. Low scorers do not experience strong, irresistible\ncravings and consequently do not find themselves tempted to overindulge."
+        "text": "Immoderate individuals feel strong cravings and\nurges that they have difficulty resisting. They tend to be\noriented toward short-term pleasures and rewards rather than long-\nterm consequences. Low scorers do not experience strong, irresistible\ncravings and consequently do not find themselves tempted to overindulge."
       },
       {
         "facet": 6,
@@ -260,4 +260,3 @@
     ]
   }
 ]
-

--- a/packages/results/src/data/en/neuroticism.ts
+++ b/packages/results/src/data/en/neuroticism.ts
@@ -90,7 +90,7 @@ nervous in social situations.`
       facet: 5,
       title: 'Immoderation',
       text: `Immoderate individuals feel strong cravings and
-urges that they have have difficulty resisting. They tend to be
+urges that they have difficulty resisting. They tend to be
 oriented toward short-term pleasures and rewards rather than long-
 term consequences. Low scorers do not experience strong, irresistible
 cravings and consequently do not find themselves tempted to overindulge.`

--- a/packages/results/src/data/is/neuroticism.ts
+++ b/packages/results/src/data/is/neuroticism.ts
@@ -65,7 +65,7 @@ nervous in social situations.`
       facet: 5,
       title: 'Immoderation',
       text: `Immoderate individuals feel strong cravings and
-urges that they have have difficulty resisting. They tend to be
+urges that they have difficulty resisting. They tend to be
 oriented toward short-term pleasures and rewards rather than long-
 term consequences. Low scorers do not experience strong, irresistible
 cravings and consequently do not find themselves tempted to overindulge.`

--- a/packages/results/test/data/get-template-en.json
+++ b/packages/results/test/data/get-template-en.json
@@ -146,7 +146,7 @@
       {
         "facet": 5,
         "title": "Immoderation",
-        "text": "Immoderate individuals feel strong cravings and\nurges that they have have difficulty resisting. They tend to be\noriented toward short-term pleasures and rewards rather than long-\nterm consequences. Low scorers do not experience strong, irresistible\ncravings and consequently do not find themselves tempted to overindulge."
+        "text": "Immoderate individuals feel strong cravings and\nurges that they have difficulty resisting. They tend to be\noriented toward short-term pleasures and rewards rather than long-\nterm consequences. Low scorers do not experience strong, irresistible\ncravings and consequently do not find themselves tempted to overindulge."
       },
       {
         "facet": 6,
@@ -260,4 +260,3 @@
     ]
   }
 ]
-

--- a/web/posts/neuroticism.md
+++ b/web/posts/neuroticism.md
@@ -50,7 +50,7 @@ Self-conscious individuals are sensitive about what others think of them. Their 
 
 ### Immoderation
 
-Immoderate individuals feel strong cravings and urges that they have have difficulty resisting. They tend to be oriented toward short-term pleasures and rewards rather than long- term consequences. Low scorers do not experience strong, irresistible cravings and consequently do not find themselves tempted to overindulge.
+Immoderate individuals feel strong cravings and urges that they have difficulty resisting. They tend to be oriented toward short-term pleasures and rewards rather than long- term consequences. Low scorers do not experience strong, irresistible cravings and consequently do not find themselves tempted to overindulge.
 
 ### Vulnerability
 


### PR DESCRIPTION
Noticed this typo while looking at a results page. I wasn't sure which of the files needed updating, so I ended up replacing in all of them--hopefully that's correct.